### PR TITLE
Correct rake task name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,22 @@ which should output something like this:
 
 ```bash
 ....
-rake audited:add_migration      # Installs Sequel::Audited migration, but does not run it.
+rake audited:migrate:install      # Installs Sequel::Audited migration, but does not run it.
 ....
 ```
 
 Run the sequel-audit rake task:
 
 ```bash
-bundle exec rake audited:add_migration
+bundle exec rake audited:migrate:install
 ```
+
 After this you can comment out the rake task in your Rakefile until you need to update. And then  
 finally run db:migrate to update your DB.
 
 ```bash
 bundle exec rake db:migrate
 ```
-
 
 ### 3)  Add the `:uuid` plugin
 


### PR DESCRIPTION
Very minor change to the name of the Rake task used to generate the migration.